### PR TITLE
Exits after the first rc file found is amended?

### DIFF
--- a/installer.php
+++ b/installer.php
@@ -95,6 +95,7 @@ if (checkpath($paths, $installdir) === false) {
             ammendpath($rcfile, $installdir, $pathUpdated);
             echo("Found " . $rcfile . " and added " . $installdir .
             " to your \$PATH.\nIn order to run Terminus, you must first run:\n\nsource ~/" . $rcfile . "\n");
+            exit;
         }
     }
     if (!$pathUpdated) {


### PR DESCRIPTION
So this change could be debated - if we update `$PATH` in every shell config file we find, we increase the chance of updating the one in use by the user.

On the other hand, it produces a lot of duplicate output in those cases, and if someone is using a non-default shell and _didn't_ clean up the other shell configuration files, maybe it's better that they are updated in case of switching.

Open to input.