### PR TITLE
Add a way to specify the version of Terminus.

### DIFF
--- a/installer.php
+++ b/installer.php
@@ -16,7 +16,7 @@ $rcfiles = array(                                  // Array of common .rc files 
 );
 $package = "terminus";
 $opts = getopt("", ["version::"]);
-$version = $opts['version'] ?? NULL;
+$version = isset($opts['version']) ? $opts['version'] : NULL;
 
 // Function to download Terminus executable file from GitHub to /tmp/ then move it to $installdir
 // prompts for sudo if required.


### PR DESCRIPTION
Add the ability to specify the version of Terminus to the installer.

Example: 

```console
$ php installer.php --version=2.6.5
```